### PR TITLE
Fixed live reload for docker

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -23,6 +23,8 @@ services:
     environment:
       - VITE_API_URL=http://localhost:8000
       - VITE_PROXY_TARGET=http://backend:8000
+    volumes:
+      - ./src:/app/src
     networks:
       - app-network
     ports:

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,9 @@ import { defineConfig } from 'vite'
 export default defineConfig({
   server: {
     allowedHosts: ['.trycloudflare.com'],
+    watch: {
+      usePolling: true,
+    },
     proxy: {
       '/api': {
         target: process.env.VITE_PROXY_TARGET || 'http://localhost:8000',


### PR DESCRIPTION
Added a volume mount to the local docker compose and polling to the Vite dev server. Now real-time updates can be seen while developing in docker.